### PR TITLE
chore: 调整目录结构展示、图标转换工具

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,7 +3,7 @@ root = true
 [*]
 charset = utf-8
 indent_style = space
-indent_size = 4
+indent_size = 2
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -61,10 +61,14 @@
     "jsonc",
     "yaml"
   ],
-  "css.customData": [".vscode/unocss.json"],
+  "css.customData": [
+    ".vscode/unocss.json"
+  ],
   "explorer.fileNesting.enabled": true,
   "explorer.fileNesting.patterns": {
-    "vite.config.*": "pages.config.*, manifest.config.*, uno.config.*, volar.config.*, *.env, .env.*"
+    "vite.config.*": "pages.config.*, manifest.config.*, uno.config.*, volar.config.*",
+    "package.json": ".npmrc, package.json, package-lock.json, yarn.lock, pnpm-lock.yaml",
+    "project.config.*": ".editorconfig, eslint.config.*, renovate.*, *.env, .env.*"
   },
   "conventionalCommits.scopes": [
     "config",

--- a/bin/convert-icon.ts
+++ b/bin/convert-icon.ts
@@ -16,7 +16,14 @@ export const iconDir = 'icon'
 // 输出目录
 export const outDir = 'temp/icons/'
 
-export async function Generated(path = iconPath, prefix = iconDir, out = outDir, noColor = true) {
+export interface ConvertOption {
+  path?: string
+  prefix?: string
+  out?: string
+  noColor?: boolean
+}
+
+export async function Generated({ path = iconPath, prefix = iconDir, out = outDir, noColor = true }: ConvertOption) {
   // Import icons
   const iconSet = await importDirectory(path, {
     prefix,
@@ -68,19 +75,39 @@ export async function Generated(path = iconPath, prefix = iconDir, out = outDir,
 
   if (!existsSync(srcDir))
     mkdirSync(srcDir)
-    // Save to file
+  // Save to file
   writeFileSync(`${out}/${iconSet.prefix}.json`, exported, 'utf8')
 
   // eslint-disable-next-line no-console
   console.log(`\x1B[32m Imported icons: \x1B[0m \x1B[31m ${Object.keys(iconSet.entries).length} \x1B[0m`)
 }
 
+// 转换
+export async function Convert(option: ConvertOption = { path: iconPath, prefix: iconDir, out: outDir, noColor: true }) {
+  await Generated(option)
+}
+
+// 多转换
+export async function Converts(options: ConvertOption[]) {
+  for (const option of options)
+    await Convert(option)
+}
+
 // vite 转换插件
-export function Convert(path = iconPath, prefix = iconDir, out = outDir, noColor = true): Plugin {
+export function ViteConvert(option: ConvertOption): Plugin {
   return {
     name: 'convert-icon',
     buildStart: async () => {
-      await Generated(path, prefix, out, noColor)
+      await Convert(option)
+    },
+  }
+}
+// vite 多转换插件
+export function ViteConverts(options: ConvertOption[]): Plugin {
+  return {
+    name: 'convert-icons',
+    buildStart: async () => {
+      await Converts(options)
     },
   }
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,10 +2,10 @@ const uni = require('@uni-helper/eslint-config')
 const unocss = require('@unocss/eslint-plugin')
 
 module.exports = uni(
+  unocss.configs.flat,
   {
     rules: {
       'no-console': 'warn',
     },
   },
-  unocss.configs.flat,
 )

--- a/project.config.ts
+++ b/project.config.ts
@@ -1,0 +1,20 @@
+import type { ConvertOption } from './bin/convert-icon'
+
+/**
+ * 图标配置
+ */
+export const icons: ConvertOption[] = [
+  {
+    path: 'src/assets/icons',
+    prefix: 'icons',
+    out: 'temp/icons/',
+    noColor: true,
+  },
+  {
+
+    path: 'src/assets/svg',
+    prefix: 'svg',
+    out: 'temp/icons/',
+    noColor: false,
+  },
+]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,73 +9,79 @@ import UnoCSS from 'unocss/vite'
 import { uniuseAutoImports } from '@uni-helper/uni-use'
 import Modules from 'vite-plugin-use-modules'
 import { uniPolyfill } from './bin/uni-polyfill'
-import { Convert } from './bin/convert-icon'
+
+// convert-icon
+import { Converts } from './bin/convert-icon'
+import { icons as ConvertsOptions } from './project.config'
 
 // https://vitejs.dev/config/
-export default defineConfig({
-  plugins: [
-    // 转换图标
-    Convert('src/assets/icons', 'icons', 'temp/icons/'),
-    Convert('src/assets/svg', 'svg', 'temp/icons/', false),
-    // https://github.com/dcloudio/uni-app/issues/4604
-    uniPolyfill(),
-    // https://github.com/uni-helper/vite-plugin-uni-manifest
-    UniHelperManifest(),
-    // https://github.com/uni-helper/vite-plugin-uni-pages
-    UniHelperPages({
-      dts: 'temp/types/uni-pages.d.ts',
-    }),
-    // https://github.com/uni-helper/vite-plugin-uni-layouts
-    UniHelperLayouts(),
-    // https://github.com/uni-helper/vite-plugin-uni-components
-    UniHelperComponents({
-      dts: 'temp/types/components.d.ts',
-      directoryAsNamespace: true,
-      deep: true,
-    }),
-    // https://github.com/dishait/vite-plugin-use-modules
-    Modules({
-      target: 'src/plugins',
-    }),
-    Uni(),
-    // https://github.com/antfu/unplugin-auto-import
-    AutoImport({
-      imports: [
-        'vue',
-        'uni-app',
-        'pinia',
-        uniuseAutoImports(),
-      ],
-      packagePresets: [
-        {
-          package: '@vueuse/core',
-          ignore: [
-            // vueuse core 默认禁用
-            'toRef',
-            'toRefs',
-            'toValue',
-            'utils',
-            // 解决 uni-use 冲突
-            'tryOnScopeDispose',
-            'useNetwork',
-            'useOnline',
-            'usePreferredDark',
-            'useStorage',
-            'useStorageAsync',
-          ],
-          cache: false,
-        },
-      ],
-      dts: 'temp/types/auto-imports.d.ts',
-      dirs: [
-        'src/composables/**',
-        'src/stores/**',
-        'src/utils/**',
-      ],
-      vueTemplate: true,
-    }),
-    // https://github.com/antfu/unocss
-    // see unocss.config.ts for config
-    UnoCSS(),
-  ],
-})
+export default async () => {
+  // convert-icon
+  await Converts(ConvertsOptions)
+
+  // https://unocss.dev
+  return defineConfig({
+    plugins: [
+      // https://github.com/dcloudio/uni-app/issues/4604
+      uniPolyfill(),
+      // https://github.com/uni-helper/vite-plugin-uni-manifest
+      UniHelperManifest(),
+      // https://github.com/uni-helper/vite-plugin-uni-pages
+      UniHelperPages({
+        dts: 'temp/types/uni-pages.d.ts',
+      }),
+      // https://github.com/uni-helper/vite-plugin-uni-layouts
+      UniHelperLayouts(),
+      // https://github.com/uni-helper/vite-plugin-uni-components
+      UniHelperComponents({
+        dts: 'temp/types/components.d.ts',
+        directoryAsNamespace: true,
+        deep: true,
+      }),
+      // https://github.com/dishait/vite-plugin-use-modules
+      Modules({
+        target: 'src/plugins',
+      }),
+      Uni(),
+      // https://github.com/antfu/unplugin-auto-import
+      AutoImport({
+        imports: [
+          'vue',
+          'uni-app',
+          'pinia',
+          uniuseAutoImports(),
+        ],
+        packagePresets: [
+          {
+            package: '@vueuse/core',
+            ignore: [
+              // vueuse core 默认禁用
+              'toRef',
+              'toRefs',
+              'toValue',
+              'utils',
+              // 解决 uni-use 冲突
+              'tryOnScopeDispose',
+              'useNetwork',
+              'useOnline',
+              'usePreferredDark',
+              'useStorage',
+              'useStorageAsync',
+            ],
+            cache: false,
+          },
+        ],
+        dts: 'temp/types/auto-imports.d.ts',
+        dirs: [
+          'src/composables/**',
+          'src/stores/**',
+          'src/utils/**',
+        ],
+        vueTemplate: true,
+      }),
+      // https://github.com/antfu/unocss
+      // see unocss.config.ts for config
+      UnoCSS(),
+    ],
+  })
+}


### PR DESCRIPTION
### PR标题：增强目录结构和图标转换工具

**目标**：此拉取请求引入了对项目目录结构和图标转换工具的增强，旨在改善文件管理和开发环境中的效率。

**主要更改**：
1. **配置文件调整**：
   - 更新了`.editorconfig`，以使用2个空格进行一致的缩进。
   - 在`.vscode/settings.json`中扩展了文件嵌套模式，以改善VSCode中的文件组织。

2. **图标转换工具的增强**：
   - 重构了`bin/convert-icon.ts`，包括新的函数`Convert`和`Converts`，提供更多样化的图标转换能力。
   - 引入了相应的Vite插件函数`ViteConvert`和`ViteConverts`，将这些转换集成到Vite构建过程中。
   - 在`project.config.ts`中添加了结构化的图标配置，以便更容易地管理和自定义。

3. **ESLint和Vite配置更新**：
   - 通过`unocss.configs.flat`增强了`eslint.config.js`，以改善linting。
   - 更新了`vite.config.ts`，以使用新的`Converts`函数，实现多个转换选项的异步处理。

**影响**：
这些更改简化了设置，并增强了开发环境的效率，特别是在文件组织和图标管理方面。