### PR TITLE
refactor: 重构网络请求工具

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-const { getKey } = useUserStore()
+const { getKey } = useAuthStore()
 onLaunch(async () => {
   await getKey()
 })

--- a/src/model/auth.ts
+++ b/src/model/auth.ts
@@ -1,0 +1,48 @@
+export const useAuthStore = defineStore('auth', {
+  state: (): {
+    /**
+     * 密钥
+     */
+    key: string
+    /**
+     * token
+     */
+    token: string
+    /**
+     * 过期时间
+     */
+    expire_time: number
+  } => ({
+    key: '',
+    token: '',
+    expire_time: 0,
+  }),
+  actions: {
+    async getKey() {
+      if (this.key)
+        return
+      const { data, code } = await http.post<loginKey>('/web/login/generate/key', {}, { auth: false })
+      if (code === 200)
+        this.key = data.loginKey
+    },
+    async getToken(code: string) {
+      const { data, code: rescode } = await http.post<LoginRes>('/web/login', {
+        code,
+        loginKey: this.key,
+        type: 'miniPrograms',
+      } as LoginReq, { auth: false })
+      if (rescode === 200) {
+        this.token = data.token
+        this.expire_time = (data.expire_time - 6000) * 1000
+      }
+    },
+    async refreshToken() {
+      const res = await http.post<LoginRes>('/web/refresh/token', {}, { auth: false, headers: { Authorization: `Bearer ${this.token}` } })
+      return res
+    },
+  },
+  persist: true,
+})
+
+if (import.meta.hot)
+  import.meta.hot.accept(acceptHMRUpdate(useAuthStore, import.meta.hot))

--- a/src/model/user.ts
+++ b/src/model/user.ts
@@ -1,14 +1,6 @@
 export const useUserStore = defineStore('user', {
   state: (): {
     /**
-     * 密钥
-     */
-    key: string
-    /**
-     * token
-     */
-    token: string
-    /**
      * 当前登录用户信息
      */
     user: UserInfo
@@ -17,8 +9,6 @@ export const useUserStore = defineStore('user', {
      */
     isRegister: boolean
   } => ({
-    key: '',
-    token: '',
     user: {} as UserInfo,
     isRegister: false,
   }),
@@ -32,23 +22,6 @@ export const useUserStore = defineStore('user', {
     },
   },
   actions: {
-    async getKey() {
-      if (this.key)
-        return
-      const { data, code } = await http.post<loginKey>('/web/login/generate/key', {}, { auth: false })
-      if (code === 200)
-        this.key = data.loginKey
-    },
-    async getToken(code: string) {
-      const { data, code: rescode } = await http.post<LoginRes>('/web/login', {
-        code,
-        loginKey: this.key,
-        type: 'miniPrograms',
-      } as LoginReq, { auth: false })
-      if (rescode === 200) {
-        this.token = data.token
-      }
-    },
     async getUserInfo() {
       const { data, code } = await http.post<UserInfo>('/web/user/info')
       if (code === 200) {

--- a/src/pages/me/login.vue
+++ b/src/pages/me/login.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 const { isRegister } = storeToRefs(useUserStore())
-const { getToken, getUserInfo } = useUserStore()
+const { getUserInfo } = useUserStore()
+const { getToken } = useAuthStore()
 const agreementChecked = ref(false)
 
 async function gologin() {

--- a/src/pages/me/me.vue
+++ b/src/pages/me/me.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 const { getUserInfo } = useUserStore()
-const { userDesc, isRegister, token } = storeToRefs(useUserStore())
+const { token } = storeToRefs(useAuthStore())
+const { userDesc, isRegister } = storeToRefs(useUserStore())
 
 onShow(async () => {
   if (token.value) {

--- a/types/request.d.ts
+++ b/types/request.d.ts
@@ -16,3 +16,58 @@ interface Page {
   pageSize: number
   total: number
 }
+
+/**
+ * 公共请求配置类型
+ */
+interface Options extends Partial<UniNamespace.RequestOptions & UniNamespace.UploadFileOption> {
+  /**
+   * 基础路径
+   */
+  baseUrl?: string
+  /**
+   * 请求头
+   */
+  headers?: { [Key: string]: string }
+  /**
+   * 请求方式
+   */
+  methods?: UniNamespace.RequestOptions['method'] | 'UPLOAD'
+  /**
+   * 是否显示加载提示
+   */
+  showLoading?: boolean
+  /**
+   * 是否需要登录
+   */
+  auth?: boolean
+
+  token?: string
+}
+
+/**
+ * 请求结果（原始）
+ */
+interface RequestSuccessCallbackResult {
+  /**
+   * 开发者服务器返回的数据
+   */
+  data: NormalResult
+  /**
+   * 开发者服务器返回的 HTTP 状态码
+   */
+  statusCode: number
+  /**
+   * 开发者服务器返回的 HTTP Response Header
+   */
+  header: any
+  /**
+   * 开发者服务器返回的 cookies，格式为字符串数组
+   */
+  cookies: string[]
+}
+
+/**
+ * 请求结果（业务通用）
+ */
+type Result<T> = NormalResult<T> & { [K in keyof T]: T[K] }

--- a/types/user.d.ts
+++ b/types/user.d.ts
@@ -24,6 +24,7 @@ interface LoginReq {
 
 interface LoginRes {
   token: string
+  expire_time: number
 }
 
 interface UserInfo {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增 `useAuthStore` 管理认证状态，包括密钥、令牌和过期时间。

- **改进**
  - 在 `App.vue` 和 `login.vue` 中，将 `getKey` 和 `getToken` 函数从 `useUserStore` 转移到 `useAuthStore`。
  - 在 `me.vue` 中，调整了从 `storeToRefs` 解构变量的位置，`token` 现在从 `useAuthStore` 获取。

- **重构**
  - 将请求处理模块重构为 `Http` 类，包含不同 HTTP 方法如 `GET`、`POST` 和 `UPLOAD` 的方法。

- **类型更新**
  - 在 `types/request.d.ts` 中添加了新接口 `Options` 和 `RequestSuccessCallbackResult`，以及泛型结果类型 `Result<T>`。
  - 在 `types/user.d.ts` 中给 `LoginRes` 接口添加了 `expire_time` 字段。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->