### PR TITLE
fix: 订单跳转、默认地址

### DIFF
--- a/src/components/address/ItemCard.vue
+++ b/src/components/address/ItemCard.vue
@@ -11,7 +11,6 @@ const emits = defineEmits<{
   editAddress: [item: addresslist]
 }>()
 
-const { nowAddress } = storeToRefs(useAddressStore())
 const { changeAddress } = useAddressStore()
 
 // 调用父组件中的删除
@@ -31,7 +30,6 @@ const editAddress = (item: addresslist) => {
 // 设置当前地址
 const setNowAddress = (index: number) => {
   changeAddress(props.addressdata[index].id)
-  nowAddress.value = props.addressdata[index]
   if (props.ischoose)
     Jump('/pages/buy/submitOrder', {}, 1)
 }

--- a/src/components/address/ItemCard.vue
+++ b/src/components/address/ItemCard.vue
@@ -12,6 +12,7 @@ const emits = defineEmits<{
 }>()
 
 const { nowAddress } = storeToRefs(useAddressStore())
+const { changeAddress } = useAddressStore()
 
 // 调用父组件中的删除
 const delAddressFn = (id: number) => {
@@ -29,6 +30,7 @@ const editAddress = (item: addresslist) => {
 
 // 设置当前地址
 const setNowAddress = (index: number) => {
+  changeAddress(props.addressdata[index].id)
   nowAddress.value = props.addressdata[index]
   if (props.ischoose)
     Jump('/pages/buy/submitOrder', {}, 1)

--- a/src/components/address/ItemCard.vue
+++ b/src/components/address/ItemCard.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
-const props = defineProps<{
+const props = withDefaults(defineProps<{
   addressdata: addresslist[]
-
-}>()
-
+  ischoose: boolean
+}>(), {
+  ischoose: false,
+})
 const emits = defineEmits<{
   deleteAddress: [id: number]
   setDefault: [item: addresslist, index: number]
@@ -29,7 +30,8 @@ const editAddress = (item: addresslist) => {
 // 设置当前地址
 const setNowAddress = (index: number) => {
   nowAddress.value = props.addressdata[index]
-  Jump('/pages/buy/submitOrder', {}, 1)
+  if (props.ischoose)
+    Jump('/pages/buy/submitOrder', {}, 1)
 }
 
 const isDefault = (item: number) => {

--- a/src/components/buys/AddressCard.vue
+++ b/src/components/buys/AddressCard.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
-const { nowAddress } = storeToRefs(useAddressStore())
+const { defaultAddress } = storeToRefs(useAddressStore())
+
 // 通过code获取省市区
 onShow(() => {
 
@@ -9,28 +10,30 @@ onShow(() => {
 <template>
   <div class="addressCard">
     <div class="center_info">
-      <div v-if="nowAddress.username" class="nameMobile">
-        <div style="display: flex; align-items: center; gap: 8rpx;">
-          <div class="usernameRow">
-            <div class="icon i-icons-address" /> {{ nowAddress.username }}
+      <template v-if="defaultAddress?.username">
+        <div class="nameMobile">
+          <div style="display: flex; align-items: center; gap: 8rpx;">
+            <div class="usernameRow">
+              <div class="icon i-icons-address" /> {{ defaultAddress.username }}
+            </div>
+            <div style="font-size: 28rpx;">
+              {{ defaultAddress.phone }}
+            </div>
+            <div v-if="defaultAddress.isDefault === 1" class="isdefault">
+              默认
+            </div>
           </div>
-          <div style="font-size: 28rpx;">
-            {{ nowAddress.phone }}
-          </div>
-          <div v-if="nowAddress.isDefault === 1" class="isdefault">
-            默认
-          </div>
+          <div class="i-icons-right" />
         </div>
-        <div class="i-icons-right" />
-      </div>
+      </template>
       <div v-else class="addressInfoTips" style="width: 156rpx;">
         <div class="icon i-icons-address" />
         <div>收货地址</div>
       </div>
-      <div v-if="!nowAddress.provinceCode" class="shadel" />
-      <div v-if="nowAddress.provinceCode" style="font-size: 28rpx;padding-left: 57rpx">
-        <span>{{ getPcaDetails([nowAddress.provinceCode, nowAddress.cityCode, nowAddress.countryCode]) }}- {{
-          nowAddress.address }}</span>
+      <div v-if="!defaultAddress?.provinceCode" class="shadel" />
+      <div v-if="defaultAddress?.provinceCode" style="font-size: 28rpx;padding-left: 57rpx">
+        <span>{{ getPcaDetails([defaultAddress.provinceCode, defaultAddress.cityCode, defaultAddress.countryCode]) }}- {{
+          defaultAddress.address }}</span>
       </div>
       <div v-else class="addressInfoTips">
         <div> 请选择/添加收货地址</div>

--- a/src/components/buys/submit/GoodsItem.vue
+++ b/src/components/buys/submit/GoodsItem.vue
@@ -122,7 +122,7 @@ const checkFn = (index: number) => {
       .goodsTitle {
         display: -webkit-box;
         -webkit-box-orient: vertical;
-        -webkit-line-clamp: 2;
+        -webkit-line-clamp: 1;
         text-overflow: ellipsis;
         overflow: hidden;
         word-break: break-all;

--- a/src/components/product/SwiperBox.vue
+++ b/src/components/product/SwiperBox.vue
@@ -34,7 +34,7 @@ const handleParams = () => {
   copyPararms.value.cpuTag2IDS = props?.params[0].product.tags2
   copyPararms.value.displayCardTag2IDs = props?.params[2].product.tags2
   copyPararms.value.resolutionType = selectPower.value === '1080' ? 1 : 2
-  copyPararms.value.gameID = props.list[pcurrent.value].id
+  copyPararms.value.gameID = props.list[pcurrent.value]?.id
   // 然后删除不需要的属性
   if (powerParams.value.cpuTag2IDS?.length === 0) {
     delete copyPararms.value.cpuTag2IDS

--- a/src/model/address.ts
+++ b/src/model/address.ts
@@ -25,9 +25,9 @@ export const useAddressStore = defineStore('address', {
     // 当前选择的地址 如没有选择则返回默认地址
     defaultAddress(state) {
       if (state.chooseid) {
-        return state.addressList.find(item => item.id === state.chooseid)
+        return state.addressList.find(item => item.id === state.chooseid) || state.nowAddress
       }
-      return state.addressList.find(item => item.isDefault === 1)
+      return state.addressList.find(item => item.isDefault === 1) || state.nowAddress
     },
   },
   actions: {
@@ -54,23 +54,6 @@ export const useAddressStore = defineStore('address', {
     // 删除地址
     async delAddress(id: number) {
       const { code } = await http.post<delReq>('/web/user/address/delete', { id }, { auth: true })
-      if (id === this.nowAddress.id) {
-        this.nowAddress = {
-          address: '',
-          cityCode: '',
-          countryCode: '',
-          createdAt: '',
-          deletedAt: null,
-          id: 0,
-          isDefault: 0,
-          phone: '',
-          provinceCode: '',
-          status: 0,
-          updatedAt: '',
-          userID: 0,
-          username: '',
-        }
-      }
       return code
     },
     // 修改地址

--- a/src/model/address.ts
+++ b/src/model/address.ts
@@ -2,6 +2,7 @@ export const useAddressStore = defineStore('address', {
   state: (): {
     addressList: addresslist[]
     nowAddress: addresslist
+    chooseid?: addresslist['id']
   } => ({
     addressList: [], // 收货地址列表
     nowAddress: {
@@ -21,9 +22,19 @@ export const useAddressStore = defineStore('address', {
     }, // 当前选择的地址
   }),
   getters: {
-
+    // 当前选择的地址 如没有选择则返回默认地址
+    defaultAddress(state) {
+      if (state.chooseid) {
+        return state.addressList.find(item => item.id === state.chooseid)
+      }
+      return state.addressList.find(item => item.isDefault === 1)
+    },
   },
   actions: {
+    // 下单时重新选择地址
+    changeAddress(id: addresslist['id']) {
+      this.chooseid = id
+    },
     // 获取收获地址列表
     async getAddressList(page: number, pageSize: number) {
       const { data, code } = await http.post<addresslist[]>('/web/user/address/list', { page, pageSize }, { auth: true })
@@ -71,24 +82,6 @@ export const useAddressStore = defineStore('address', {
           icon: 'error',
         })
       }
-    },
-
-    async demoAddress() {
-      this.addressList.push({
-        address: '3213',
-        cityCode: '110100000000',
-        countryCode: '110101000000',
-        createdAt: '2024-06-13 11:34:18',
-        deletedAt: null,
-        id: 108,
-        isDefault: 1,
-        phone: '213213',
-        provinceCode: '110000000000',
-        status: 1,
-        updatedAt: '2024-06-13 11:34:18',
-        userID: 104,
-        username: 'sun',
-      })
     },
 
   },

--- a/src/pages/buy/submitOrder.vue
+++ b/src/pages/buy/submitOrder.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-const { nowAddress } = storeToRefs(useAddressStore())
+const { defaultAddress } = storeToRefs(useAddressStore())
 const { products } = storeToRefs(useBuyStore())
 const { detail } = storeToRefs(useProductStore())
 const { canUseCouponNum } = storeToRefs(useSubmitOrderStore())
@@ -22,7 +22,7 @@ const submitOrderParams = ref<submitOrderReq>({
   inviteCode: '',
   details: [],
   userTicketID: 0,
-  userAddressID: nowAddress.value.id,
+  userAddressID: defaultAddress.value.id,
   payType: 'wechat',
   payMethod: 'mp',
   remark: '',
@@ -116,7 +116,7 @@ onMounted(async () => {
 
     submitOrderParams.value.details = arr.value
     // 查询可用的优惠券
-    await canUseCoupon(nowAddress.value.id, productIDs.value, undefined)
+    await canUseCoupon(defaultAddress.value.id, productIDs.value, undefined)
   }
 })
 </script>

--- a/src/pages/buy/submitOrder.vue
+++ b/src/pages/buy/submitOrder.vue
@@ -131,7 +131,7 @@ onMounted(async () => {
     <buys-submit-goods-item :list="nowGoods" :goods="detail" :showborder="showborder" @checked="checkAllocation" />
 
     <div class="CouponsAndNotes">
-      <div class="counpons" @click="Jump('/pages/buy/selectCoupon', {}, 1)">
+      <div class="counpons" @click="Jump('/pages/buy/selectCoupon')">
         <div>优惠券</div>
         <div class="beColor">
           <template v-if="couponPrice !== ''">

--- a/src/pages/buy/submitOrder.vue
+++ b/src/pages/buy/submitOrder.vue
@@ -124,7 +124,7 @@ onMounted(async () => {
 <template>
   <navbar-back text="提交订单" />
   <div class="body">
-    <div class="addressBox" @click="Jump('/pages/me/address/index', {}, 1)">
+    <div class="addressBox" @click="Jump('/pages/me/address/index', { type: true }, 1)">
       <buys-address-card />
     </div>
 

--- a/src/pages/index/index.vue
+++ b/src/pages/index/index.vue
@@ -72,7 +72,7 @@ async function getProductsByType(type: number) {
 <style lang="scss" scoped>
   .index {
     margin-top: calc((var(--navbar-height-all) - var(--navbar-top)) * -1);
-
+    overflow: hidden;
     .about {
       @apply flex-center;
 

--- a/src/pages/me/address/index.vue
+++ b/src/pages/me/address/index.vue
@@ -220,6 +220,14 @@ onMounted(() => {
   // 初始化数据
   initAddress()
 })
+const ischoose = ref<boolean>(false)
+
+// 下单时传递一个type 参数，表示从下单页面跳转过来的
+onLoad((params) => {
+  if (params?.type) {
+    ischoose.value = true
+  }
+})
 </script>
 
 <template>
@@ -231,6 +239,7 @@ onMounted(() => {
         <common-empty text="当前暂无收货地址,快去添加吧！" icon="i-svg-union" />
       </div>
       <address-item-card
+        :ischoose="ischoose"
         :addressdata="addressList" @delete-address="delAddressFn" @set-default="setDefaultFn"
         @edit-address="editAddressFn"
       />
@@ -243,7 +252,7 @@ onMounted(() => {
         <div class="inputBox">
           <div class="row">
             <div>收货人</div>
-            <input v-model="addReqParams.username" type="text">
+            <input v-model="addReqParams.username" class="inp" type="text">
           </div>
           <div class="row">
             <div>联系电话</div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 在地址选择页面（`index.vue`）中添加了`ischoose`参数，以便在订单提交时跳转。

- **改进**
  - 将`ItemCard.vue`中的`setNowAddress`函数更新为使用`changeAddress`。
  - 将`AddressCard.vue`中的`nowAddress`重命名为`defaultAddress`，并更新相关绑定。
  - 修改`GoodsItem.vue`中的`goodsTitle`样式，将`-webkit-line-clamp`属性从`2`调整为`1`。
  - 更新`SwiperBox.vue`中的`handleParams`函数，确保安全访问`id`属性。

- **修复**
  - 修复了删除地址时未正确重置`nowAddress`的问题。

- **样式**
  - 在`index.vue`中为`.index`类添加`overflow: hidden;`样式，以隐藏溢出内容。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->