### PR TITLE
fix: 首页 banner 加载错误

### DIFF
--- a/src/components/index/carousel/Banner.vue
+++ b/src/components/index/carousel/Banner.vue
@@ -3,7 +3,10 @@ const props = defineProps<{
   list: WindowsImage[]
 }>()
 
-const bannerImages = ref<WindowsImage[]>(props.list)
+const bannerImages = ref<WindowsImage[]>([])
+watchEffect(() => {
+  bannerImages.value = props.list
+})
 
 const bannerSwiper = ref()
 const current = ref(0)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **错误修复**
	- 修复了 `Banner.vue` 组件中 `bannerImages` 初始化错误的问题，现在会正确更新为传入的 `props.list`。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->