### PR TITLE
style: 邀请输入框调整高度

### DIFF
--- a/src/components/popularize/BindInviter.vue
+++ b/src/components/popularize/BindInviter.vue
@@ -173,16 +173,16 @@ defineExpose({
     }
 
     .body {
-      width: 66%;
+      width:60%;
       padding: 60rpx 0;
       text-align: center;
     }
 
     .footer {
-      width: 66%;
+      width: 60%;
       display: flex;
       align-items: center;
-      justify-content: space-around;
+      justify-content: space-between;
       padding-bottom: 50rpx;
 
       .btn {
@@ -227,9 +227,9 @@ defineExpose({
     font-size: 26rpx;
     color: #000;
     background: #D9D9D9;
-    width: 66%;
+    width: 100%;
     border-radius: 12rpx;
-    padding: 2rpx 0;
+    padding: 12rpx 0;
   }
 }
 </style>

--- a/src/components/popularize/RecordList.vue
+++ b/src/components/popularize/RecordList.vue
@@ -99,30 +99,35 @@ function reachBottom() {
           </template>
         </div>
         <div>
-          <scroll-view class="list_scroll" :scroll-y="true" @scrolltolower="reachBottom">
-            <template v-for="(item, index) in !tabIndex ? rebatelist : withdrawlist" :key="index">
-              <div class="title_list">
-                <div class="title_text">
-                  {{ !tabIndex ? forString(item.orderNO) : forString(item.no) }}
+          <template v-if="!tabIndex ? rebatelist && rebatelist.length > 0 : withdrawlist && withdrawlist.length > 0">
+            <scroll-view class="list_scroll" :scroll-y="true" @scrolltolower="reachBottom">
+              <template v-for="(item, index) in !tabIndex ? rebatelist : withdrawlist" :key="index">
+                <div class="title_list">
+                  <div class="title_text">
+                    {{ !tabIndex ? forString(item.orderNO) : forString(item.no) }}
+                  </div>
+                  <div class="title_text">
+                    {{ !tabIndex ? item.userInfo.nickname : '' }}
+                  </div>
+                  <div class="title_text">
+                    {{ !tabIndex ? item.rebateAmount : item.withdrawAmount }}
+                  </div>
+                  <div class="title_text">
+                    {{ !tabIndex ? rebateStatus(item.status) : item.balanceAmountAfter }}
+                  </div>
+                  <div class="title_text">
+                    {{ !tabIndex ? item.createdAt : item.auditedAt }}
+                  </div>
+                  <div class="title_text">
+                    {{ !tabIndex ? item.updatedAt : withdrawStatus[item.status - 1] }}
+                  </div>
                 </div>
-                <div class="title_text">
-                  {{ !tabIndex ? item.userInfo.nickname : '' }}
-                </div>
-                <div class="title_text">
-                  {{ !tabIndex ? item.rebateAmount : item.withdrawAmount }}
-                </div>
-                <div class="title_text">
-                  {{ !tabIndex ? rebateStatus(item.status) : item.balanceAmountAfter }}
-                </div>
-                <div class="title_text">
-                  {{ !tabIndex ? item.createdAt : item.auditedAt }}
-                </div>
-                <div class="title_text">
-                  {{ !tabIndex ? item.updatedAt : withdrawStatus[item.status - 1] }}
-                </div>
-              </div>
-            </template>
-          </scroll-view>
+              </template>
+            </scroll-view>
+          </template>
+          <template v-else>
+            <common-empty text="暂无记录" />
+          </template>
         </div>
       </div>
     </div>
@@ -130,121 +135,118 @@ function reachBottom() {
 </template>
 
 <style lang="scss" scoped>
-  .record_list {
-    position: relative;
-    z-index: 0;
+.record_list {
+  position: relative;
+  z-index: 0;
+  overflow: hidden;
+  background-color: rgba($color: #000000, $alpha: .6);
+
+  width: calc(100% - 64rpx);
+  height: 720rpx;
+
+  margin: 0 auto;
+  margin-top: 32rpx;
+  border-radius: 32rpx;
+
+  &::before {
+    position: absolute;
+    z-index: -1;
     overflow: hidden;
-    background-color: rgba($color: #000000, $alpha: .6);
 
-    width: calc(100% - 64rpx);
-    height: 720rpx;
-
-    margin: 0 auto;
-    margin-top: 32rpx;
+    display: block;
+    content: "";
     border-radius: 32rpx;
+    background: rgba(0, 0, 0, 0.6);
+    border: 2rpx solid transparent;
+    background: linear-gradient(113.84deg,
+        rgba(255, 255, 255, 0.8) -6.55%,
+        rgba(255, 255, 255, 0.08) 46.47%,
+        rgba(255, 255, 255, 0.8) 92.28%) border-box;
+    mask: linear-gradient(#fff 0 0) padding-box, linear-gradient(#fff 0 0);
+    mask-composite: exclude;
+    width: 100%;
+    height: 100%;
+  }
 
-    &::before {
+  .tab_text {
+    display: inline-block;
+    font-family: PingFang SC;
+    font-size: 28rpx;
+    font-weight: 400;
+    text-align: center;
+    margin-left: 40rpx;
+    margin-top: 32rpx;
+  }
+
+  .withdraw_tab_rebate {
+    display: inline-block;
+    margin-left: 40rpx;
+    margin-top: 32rpx;
+    font-family: PingFang SC;
+    font-size: 32rpx;
+    font-weight: 600;
+    position: relative;
+    padding-bottom: 5rpx;
+
+    .tab_svg {
+      width: 120%;
+      height: 16rpx;
       position: absolute;
+      bottom: 0;
+      left: 50%;
       z-index: -1;
-      overflow: hidden;
-
-      display: block;
-      content: "";
-      border-radius: 32rpx;
-      background: rgba(0, 0, 0, 0.6);
-      border: 2rpx solid transparent;
-      background: linear-gradient(113.84deg,
-          rgba(255, 255, 255, 0.8) -6.55%,
-          rgba(255, 255, 255, 0.08) 46.47%,
-          rgba(255, 255, 255, 0.8) 92.28%) border-box;
-      mask: linear-gradient(#fff 0 0) padding-box, linear-gradient(#fff 0 0);
-      mask-composite: exclude;
-      width: 100%;
-      height: 100%;
+      transform: translateX(-50%);
     }
+  }
 
-    .tab_text {
-      display: inline-block;
-      font-family: PingFang SC;
-      font-size: 28rpx;
-      font-weight: 400;
-      text-align: center;
-      margin-left: 40rpx;
-      margin-top: 32rpx;
-    }
+  .scroll_view {
+    width: calc(100% - 64rpx);
+    margin: 0 auto;
+    overflow-x: scroll;
 
-    .withdraw_tab_rebate {
-      display: inline-block;
-      margin-left: 40rpx;
-      margin-top: 32rpx;
-      font-family: PingFang SC;
-      font-size: 32rpx;
-      font-weight: 600;
-      position: relative;
-      padding-bottom: 5rpx;
+    .title_tab {
+      height: 80rpx;
+      margin-top: 48rpx;
+      border-radius: 8rpx;
+      white-space: nowrap;
+      float: left;
+      background: linear-gradient(0deg, rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0.2)),
+        linear-gradient(0deg,
+          rgba(132, 132, 132, 0.2),
+          rgba(132, 132, 132, 0.2));
 
-      .tab_svg {
-        width: 120%;
-        height: 16rpx;
-        position: absolute;
-        bottom: 0;
-        left: 50%;
-        z-index: -1;
-        transform: translateX(-50%);
+      .title_text {
+        display: inline-block;
+        width: 240rpx;
+        line-height: 80rpx;
+        font-size: 28rpx;
+        font-weight: 400;
+        text-align: center;
       }
     }
 
-    .scroll_view {
-      width: calc(100% - 64rpx);
-      margin: 0 auto;
-      overflow-x: scroll;
+    .list_scroll {
+      width: 1440rpx;
+      height: 450rpx;
+      overflow-y: scroll;
 
-      .title_tab {
-        height: 80rpx;
-        margin-top: 48rpx;
-        border-radius: 8rpx;
-        white-space: nowrap;
-        float: left;
-        background: linear-gradient(0deg, rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0.2)),
-          linear-gradient(0deg,
-            rgba(132, 132, 132, 0.2),
-            rgba(132, 132, 132, 0.2));
+      .title_list {
+        text-align: center;
+        font-size: 28rpx;
+        font-weight: 400;
+        text-align: center;
+        margin-top: 36rpx;
+        display: flex;
+        align-items: center;
 
         .title_text {
-          display: inline-block;
           width: 240rpx;
-          line-height: 80rpx;
           font-size: 28rpx;
           font-weight: 400;
           text-align: center;
-        }
-      }
-
-      .list_scroll {
-        width: 1440rpx;
-        height: 450rpx;
-        overflow-y: scroll;
-
-        .title_list {
-          line-height: 80rpx;
-          text-align: center;
-          white-space: nowrap;
-          font-size: 28rpx;
-          font-weight: 400;
-          text-align: center;
-          margin-top: 36rpx;
-          float: left;
-
-          .title_text {
-            width: 240rpx;
-            line-height: 80rpx;
-            font-size: 28rpx;
-            display: inline-block;
-            font-weight: 400;
-            text-align: center;
-          }
         }
       }
     }
   }
+}
 </style>

--- a/src/components/popularize/RecordList.vue
+++ b/src/components/popularize/RecordList.vue
@@ -107,7 +107,7 @@ function reachBottom() {
                     {{ !tabIndex ? forString(item.orderNO) : forString(item.no) }}
                   </div>
                   <div class="title_text">
-                    {{ !tabIndex ? item.userInfo.nickname : '' }}
+                    {{ !tabIndex ? item.userInfo.nickname : '提现' }}
                   </div>
                   <div class="title_text">
                     {{ !tabIndex ? item.rebateAmount : item.withdrawAmount }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **样式**
  - 调整了 `BindInviter.vue` 中 `.body` 和 `.footer` 的宽度为 60%，并将 `.footer` 的 `justify-content` 属性改为 `space-between`。 `.input` 元素的宽度改为 100%，并调整了填充为 12rpx。
- **功能性改动**
  - 修改了 `RecordList.vue` 中基于 `tabIndex` 显示列表的功能。根据 `rebatelist` 和 `withdrawlist` 的长度有条件地渲染不同内容。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->