### PR TITLE
fix: 修改订单页面 查看详情跳转

### DIFF
--- a/src/components/buys/OrderInfoBottom.vue
+++ b/src/components/buys/OrderInfoBottom.vue
@@ -42,6 +42,7 @@ const cancelPay = () => {
   bottom: 0;
   width: 100%;
   background-color: #414141;
+  z-index: 5;
 
   .Tobepaid {
     height: 100%;

--- a/src/components/buys/submit/OrderinfoGoods.vue
+++ b/src/components/buys/submit/OrderinfoGoods.vue
@@ -139,7 +139,7 @@ const isSrc = (Item: any) => {
       // height: 144rpx;
       flex: 1;
       padding-left: 24rpx;
-      z-index: 10;
+      z-index: 2;
       .goodsTitle {
         font-weight: 500;
         font-size: 28rpx;

--- a/src/components/product/custom/Peripheral.vue
+++ b/src/components/product/custom/Peripheral.vue
@@ -124,12 +124,42 @@ const addPeriheralsFn = () => {
   shows.value = false
 }
 
+const ProductselectPeripheralItem = ref<ComponentInstance['ProductCustomSelectPeripheral']>()
+
+// 已选外设弹窗
+const selectshows = ref<boolean>(false)
 // 展示已选
 const showSelectedFn = () => {
   // 点击已选 弹出啊 已选弹窗
-  ProductPeripheralItem.value?.openSelect()
+  selectshows.value = true
 }
 
+// 合计
+const totalPrice = computed(() => {
+  let result = 0
+  detail.value?.perihera?.forEach((item: any) => {
+    result += (item.number * Number(item.sellPrice))
+  })
+  return result
+})
+// 数量
+const totalNum = computed(() => {
+  let result = 0
+  detail.value?.perihera.forEach((item: any) => {
+    result += item.number
+  })
+  return result
+})
+const closed = () => {
+  ProductPeripheralItem.value?.closed()
+}
+// 查看配置详情的数据
+const showConfigs = ref<any | null>(null)
+const showConfigsSwitch = ref<boolean>(false)
+const checkInfo = (index: number) => {
+  showConfigs.value = detail.value?.perihera[index]
+  showConfigsSwitch.value = true
+}
 defineExpose({
   setShow,
 })
@@ -181,6 +211,28 @@ defineExpose({
         />
       </div>
     </common-popup>
+
+    <common-popup v-model:show="selectshows" name="已选外设" height="70%" @close="closed">
+      <div>
+        <product-custom-select-peripheral ref="ProductselectPeripheralItem" @checkload="checkInfo" />
+      </div>
+      <template #footer>
+        <div class="bottom">
+          <div class="numberbox">
+            <div class="total">
+              合计 <span class="temcolor pricefs">￥{{ totalPrice || 0 }}</span>
+            </div>
+            <div class="num">
+              数量 <span class="temcolor pricefs">x{{ totalNum }}</span>
+            </div>
+          </div>
+        </div>
+      </template>
+    </common-popup>
+
+    <common-popup v-model:show="showConfigsSwitch" name="配置详情">
+      <buys-show-alloaction :config="showConfigs" />
+    </common-popup>
   </div>
 </template>
 
@@ -196,6 +248,140 @@ defineExpose({
     .scrollpb {
       padding-bottom: 80rpx;
     }
+  }
+
+  .bottom {
+    padding: 32rpx;
+    padding-bottom: calc(32rpx + env(safe-area-inset-bottom));
+    width: 100%;
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    background-color: rgba(#444444, 0.6);
+    backdrop-filter: blur(48rpx);
+    color: #f5f5f5;
+    z-index: 9;
+    box-shadow: 0px -2rpx 10rpx 0px rgba(0, 0, 0, 0.05);
+    @apply flex-between;
+
+    .numberbox {
+      width: 100%;
+      @apply flex-between;
+    }
+
+    .total,
+    .num {
+      font-size: 28rpx;
+    }
+
+    .temcolor {
+      margin-left: 8rpx;
+      color: #A7F522;
+    }
+
+    .pricefs {
+      font-size: 40rpx;
+      font-weight: 600;
+    }
+
+    .right {
+      display: flex;
+      align-items: center;
+      color: #000;
+      position: relative;
+      width: 420rpx;
+      height: 80rpx;
+
+      .confirm,
+      .cancel,
+      .confirm2 {
+        position: absolute;
+        right: 32rpx;
+        width: 200rpx;
+        height: 80rpx;
+        line-height: 80rpx;
+        font-size: 28rpx;
+        font-weight: 400;
+        // margin-right: 40rpx;
+        color: #000;
+        text-align: center;
+        z-index: 10;
+        padding-left: 50rpx;
+
+        &::after {
+          content: "";
+          position: absolute;
+          top: 0;
+          left: 26rpx;
+          right: 0;
+          bottom: 0;
+          border-radius: 30rpx;
+          height: 80rpx;
+          background: #A7F522;
+          transform: skewX(-30deg);
+          z-index: -1;
+          border-top-left-radius: 20rpx;
+        }
+
+        &::before {
+          content: "";
+          position: absolute;
+          top: 0;
+          right: -20rpx;
+          width: 162rpx;
+          height: 80rpx;
+          border-radius: 25rpx;
+          background: #A7F522;
+          z-index: -1;
+
+        }
+
+      }
+
+      .confirm2 {
+        position: absolute;
+        top: 8rpx;
+        left: 8rpx;
+        z-index: -2;
+
+        &::after {
+          background-color: #57683B;
+        }
+
+        &::before {
+          background-color: #57683B;
+        }
+      }
+
+      .cancel {
+        left: 6rpx;
+        padding-left: 46rpx;
+        padding-right: 67rpx;
+
+        &::after {
+          left: 24rpx;
+          border-radius: 30rpx;
+          height: 80rpx;
+          background: #ffffff;
+          transform: skewX(-30deg);
+          z-index: -1;
+          border-bottom-right-radius: 20rpx;
+        }
+
+        &::before {
+
+          right: 21rpx;
+          width: 200rpx;
+          height: 80rpx;
+          border-radius: 25rpx;
+          background: #ffffff;
+          z-index: -1;
+
+        }
+      }
+
+    }
+
   }
 }
 

--- a/src/components/product/custom/Peripheralitem.vue
+++ b/src/components/product/custom/Peripheralitem.vue
@@ -52,16 +52,6 @@ const isSelect = (id: number) => {
   }
 }
 
-const ProductselectPeripheralItem = ref<ComponentInstance['ProductCustomSelectPeripheral']>()
-
-// 已选外设弹窗
-const selectshows = ref<boolean>(false)
-
-// 打开已选
-const openSelect = () => {
-  selectshows.value = true
-}
-
 const confirmSelect = () => {
   // 确认选中
   if (!detail.value) {
@@ -108,32 +98,13 @@ const checkInfo = (index: number) => {
   if (!info) {
     return
   }
-
   showConfigs.value = info
-
   showConfigsSwitch.value = true
 }
 
-// 合计
-const totalPrice = computed(() => {
-  let result = 0
-  detail.value?.perihera?.forEach((item: any) => {
-    result += (item.number * Number(item.sellPrice))
-  })
-  return result
-})
-// 数量
-const totalNum = computed(() => {
-  let result = 0
-  detail.value?.perihera.forEach((item: any) => {
-    result += item.number
-  })
-  return result
-})
-
 defineExpose({
   showEvery,
-  openSelect,
+  closed,
   confirmSelect,
   Processing,
 })
@@ -214,23 +185,6 @@ defineExpose({
         <common-empty text="商品列表为空~" padding="0" />
       </div>
     </template>
-    <common-popup v-model:show="selectshows" name="已选外设" height="70%" @close="closed">
-      <div>
-        <product-custom-select-peripheral ref="ProductselectPeripheralItem" />
-      </div>
-      <template #footer>
-        <div class="bottom">
-          <div class="numberbox">
-            <div class="total">
-              合计 <span class="temcolor pricefs">￥{{ totalPrice || 0 }}</span>
-            </div>
-            <div class="num">
-              数量 <span class="temcolor pricefs">x{{ totalNum }}</span>
-            </div>
-          </div>
-        </div>
-      </template>
-    </common-popup>
 
     <common-popup v-model:show="showConfigsSwitch" name="配置详情">
       <buys-show-alloaction :config="showConfigs" />
@@ -390,140 +344,6 @@ defineExpose({
         font-size: 24rpx;
       }
     }
-  }
-
-}
-
-.bottom {
-  padding: 32rpx;
-  padding-bottom: calc(32rpx + env(safe-area-inset-bottom));
-  width: 100%;
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  background-color: rgba(#444444, 0.6);
-  backdrop-filter: blur(48rpx);
-  color: #f5f5f5;
-  z-index: 9;
-  box-shadow: 0px -2rpx 10rpx 0px rgba(0, 0, 0, 0.05);
-  @apply flex-between;
-
-  .numberbox {
-    width: 100%;
-    @apply flex-between;
-  }
-
-  .total,
-  .num {
-    font-size: 28rpx;
-  }
-
-  .temcolor {
-    margin-left: 8rpx;
-    color: #A7F522;
-  }
-
-  .pricefs {
-    font-size: 40rpx;
-    font-weight: 600;
-  }
-
-  .right {
-    display: flex;
-    align-items: center;
-    color: #000;
-    position: relative;
-    width: 420rpx;
-    height: 80rpx;
-
-    .confirm,
-    .cancel,
-    .confirm2 {
-      position: absolute;
-      right: 32rpx;
-      width: 200rpx;
-      height: 80rpx;
-      line-height: 80rpx;
-      font-size: 28rpx;
-      font-weight: 400;
-      // margin-right: 40rpx;
-      color: #000;
-      text-align: center;
-      z-index: 10;
-      padding-left: 50rpx;
-
-      &::after {
-        content: "";
-        position: absolute;
-        top: 0;
-        left: 26rpx;
-        right: 0;
-        bottom: 0;
-        border-radius: 30rpx;
-        height: 80rpx;
-        background: #A7F522;
-        transform: skewX(-30deg);
-        z-index: -1;
-        border-top-left-radius: 20rpx;
-      }
-
-      &::before {
-        content: "";
-        position: absolute;
-        top: 0;
-        right: -20rpx;
-        width: 162rpx;
-        height: 80rpx;
-        border-radius: 25rpx;
-        background: #A7F522;
-        z-index: -1;
-
-      }
-
-    }
-
-    .confirm2 {
-      position: absolute;
-      top: 8rpx;
-      left: 8rpx;
-      z-index: -2;
-
-      &::after {
-        background-color: #57683B;
-      }
-
-      &::before {
-        background-color: #57683B;
-      }
-    }
-
-    .cancel {
-      left: 6rpx;
-      padding-left: 46rpx;
-      padding-right: 67rpx;
-
-      &::after {
-        left: 24rpx;
-        border-radius: 30rpx;
-        height: 80rpx;
-        background: #ffffff;
-        transform: skewX(-30deg);
-        z-index: -1;
-        border-bottom-right-radius: 20rpx;
-      }
-
-      &::before {
-
-        right: 21rpx;
-        width: 200rpx;
-        height: 80rpx;
-        border-radius: 25rpx;
-        background: #ffffff;
-        z-index: -1;
-
-      }
-    }
-
   }
 
 }

--- a/src/components/product/custom/SelectPeripheral.vue
+++ b/src/components/product/custom/SelectPeripheral.vue
@@ -1,4 +1,7 @@
 <script setup lang="ts">
+const emits = defineEmits<{
+  checkload: [index: number]
+}>()
 const { detail } = storeToRefs(useProductStore())
 // 预删除外设
 const delSelect = (id: number) => {
@@ -32,6 +35,10 @@ const setNumber = (str: string, id: number) => {
     }
     detail.value.perihera[index].number = num
   }
+}
+
+const checkInfo = (index: number) => {
+  emits('checkload', index)
 }
 
 // 是否选中
@@ -74,7 +81,7 @@ const isSelect = (id: number) => {
               {{ item.description }}
             </div>
             <div class="row3">
-              <div class=" check">
+              <div class=" check" @click="checkInfo(index)">
                 查看详情
                 <div class="i-icons-right" />
               </div>

--- a/src/pages/buy/orderInfo.vue
+++ b/src/pages/buy/orderInfo.vue
@@ -49,16 +49,14 @@ onLoad((options) => {
 const showConfigsSwitch = ref<boolean>(false)
 const showConfigs = ref<any>(null)
 const checkinfo = (index: number) => {
-  const arr = detail.value?.details?.[index].productConfigSnapshot?.params || []
-  arr.forEach((x: any) => {
-    detail.value?.details?.[index].products?.forEach((item) => {
-      if (x.pID === item.id) {
-        item.number = x.num
-      }
-    })
-  })
-  showConfigs.value = detail.value?.details?.[index].products
-  showConfigsSwitch.value = true
+  const config_id = detail.value?.details?.[index].productConfigID
+  const id = detail.value?.details?.[index].productID
+  if (config_id) {
+    Jump('/pages/product/diy', { config_id })
+  }
+  else {
+    Jump('/pages/product/detail', { id })
+  }
 }
 onShow(async () => {
   // 给请求 添加商品


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 增加了对选择外设的管理功能，包括计算总价和总数，以及显示配置详情。
  - 在产品页面增加了基于配置可用性重定向的功能。

- **样式更新**
  - 修改了`OrderInfoBottom.vue`组件的`z-index`属性以调整背景颜色的层叠顺序。
  - 修改了`OrderinfoGoods.vue`组件的`.goodsTitle`类的`z-index`属性影响页面元素的堆叠顺序。

- **重构**
  - `SelectPeripheral.vue`文件中引入了事件处理逻辑并重构点击事件的检查详情逻辑。
  - `Peripheralitem.vue`文件中移除了旧功能并更新了模板和样式。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->