### PR TITLE
fix: 配置单分享路径错误

### DIFF
--- a/src/pages/me/configList/configuration.vue
+++ b/src/pages/me/configList/configuration.vue
@@ -75,7 +75,7 @@ onShareAppMessage(async ({ from, target }) => {
 
     return {
       title: `配置单${shareItem?.id}`,
-      path: `/pages/configure/diy?config_id=${shareItem?.id}`,
+      path: `/pages/product/diy?config_id=${shareItem?.id}`,
       imageUrl: banner,
     }
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
	- 修改了共享功能的路由，用户现在可以通过共享链接直接访问不同的配置页面。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->