### PR TITLE
fix: 推广绑定判断增强

### DIFF
--- a/src/components/invite/Banner.vue
+++ b/src/components/invite/Banner.vue
@@ -26,7 +26,7 @@ const inviterText = computed(() => props.user?.inviteUserInfo ? props.user.invit
       </div>
       <div class="flex-center mt-10 ml-6 mr-6">
         <span class="my-inviter">我的邀请人：{{ inviterText }}</span>
-        <span class="btn-inviter" @click="band">{{ props.user.promoterStatus === 1 ? '换绑' : '绑定邀请人 ' }}</span>
+        <span class="btn-inviter" @click="band">{{ props.user.inviteUserInfo?.inviteCode ? '换绑' : '绑定邀请人 ' }}</span>
       </div>
       <div class="flex justify-center mt-2">
         <template v-if="props.user.promoterStatus !== 1">

--- a/src/components/popularize/BindInviter.vue
+++ b/src/components/popularize/BindInviter.vue
@@ -71,7 +71,7 @@ defineExpose({
       </div>
       <div class="body">
         <div class="msg">
-          {{ props.user.promoterStatus === 1 ? '换绑' : '绑定邀请人 ' }}邀请人
+          {{ props.user.inviteUserInfo?.inviteCode ? '换绑' : '绑定邀请人 ' }}邀请人
         </div>
         <div class="codeinp flex-center pt-2">
           <input v-model="code" placeholder="请输入邀请人邀请码" type="text" class="inp mt-1">

--- a/src/pages/me/me.vue
+++ b/src/pages/me/me.vue
@@ -118,7 +118,7 @@ const activities = () => {
 const promotion = () => {
   if (hasGoLogin())
     return
-  if (!user.value?.promoterStatus) {
+  if (user.value?.promoterStatus !== 1) {
     uni.showToast({
       title: '请先成为推广员',
       icon: 'none',

--- a/src/pages/popularize/invitetion.vue
+++ b/src/pages/popularize/invitetion.vue
@@ -21,6 +21,7 @@ async function become() {
   }
   const res = await becomePromoter()
   if (res.code === 200) {
+    getUserInfo()
     uni.showToast({
       title: '加入成功',
       icon: 'none',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
	- 更新了邀请人绑定按钮的文本显示逻辑，现在根据用户的邀请代码显示内容。
	- 在用户页面中，推广状态的检查逻辑更加明确，仅在用户的推广状态不等于 `1` 时才触发通知。

- **Bug 修复**
	- 改进了条件渲染逻辑，以确保显示的文本更准确地反映用户的邀请状态。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->